### PR TITLE
Add optional _id argument to insert-file!

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -703,14 +703,16 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
    Options include:
    :filename    -> defaults to nil
    :contentType -> defaults to nil
-   :metadata    -> defaults to nil"
+   :metadata    -> defaults to nil
+   :_id         -> defaults to nil (autogenerate)"
   {:arglists '([fs data {:filename nil :contentType nil :metadata nil}])}
-  [fs data & {:keys [^String filename ^String contentType ^DBObject metadata]
-              :or {filename nil contentType nil metadata nil}}]
+  [fs data & {:keys [^String filename ^String contentType ^DBObject metadata _id]
+              :or {filename nil contentType nil metadata nil _id nil}}]
   (let [^com.mongodb.gridfs.GridFSInputFile f (.createFile ^GridFS (get-gridfs fs) data)]
     (if filename (.setFilename f ^String filename))
     (if contentType (.setContentType f contentType))
     (if metadata (.setMetaData f (coerce metadata [:clojure :mongo])))
+    (if _id (.setId f _id))
     (.save f)
     (coerce f [:mongo :clojure])))
 

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -7,7 +7,8 @@
   (:use [clojure.data.json :only (read-str write-str)])
   (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder MongoException$DuplicateKey
             ReadPreference
-            WriteConcern]))
+            WriteConcern]
+           [org.bson.types ObjectId]))
 
 (deftest coercions
   (let [clojure      (array-map :a
@@ -638,6 +639,14 @@
                           :metadata {:calories 50, :opinion "tasty"})]
       (is (= "tasty" (get-in f [:metadata :opinion])))
       (is (= f (fetch-one-file :testfs :where { :metadata.opinion "tasty" }))))))
+
+(deftest gridfs-insert-with-id
+  (with-test-mongo
+    (let [file-id (ObjectId.)
+          f (insert-file! :testfs (.getBytes "nuts")
+                          :_id file-id)]
+      (is (= file-id (get f :_id)))
+      (is (= f (fetch-one-file :testfs :where { :_id file-id }))))))
 
 (deftest gridfs-write-file-to
   (with-test-mongo


### PR DESCRIPTION
Hi!

We have a use-case where we have a separate process that is creating and inserting files into GridFS. The creation is initiated from another process, that needs to know the ID of the finished file in order to be able to fetch it when it is ready.

We therefore need to be able to manually choose a id and pass it to insert-file! so that we know where we can find it afterwards. We added this as an optional argument that defaults to nil and the previous behaviour that lets MongoDB choose the id.

Best Regards
Johan